### PR TITLE
DLS-7038 | Fix MRC to handle FY without margin relief config

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,8 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.1.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.13")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.15")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "1.9.3")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.6")

--- a/test/calculator/MarginalReliefCalculatorImplSpec.scala
+++ b/test/calculator/MarginalReliefCalculatorImplSpec.scala
@@ -859,10 +859,10 @@ class MarginalReliefCalculatorImplSpec extends AnyWordSpec with Matchers {
               131849.32,
               0.0,
               131849.32,
-              12557.08,
-              62785.39,
+              12522.77,
+              62613.84,
               275,
-              FYRatio(275, 365)
+              FYRatio(275, 366)
             ),
             23.52
           ).valid
@@ -960,18 +960,18 @@ class MarginalReliefCalculatorImplSpec extends AnyWordSpec with Matchers {
             2023,
             11301.37,
             25.0,
-            11037.67,
+            11040.24,
             24.42,
-            263.7,
+            261.13,
             45205.48,
             0.0,
             45205.48,
-            12557.08,
-            62785.39,
+            12522.77,
+            62613.84,
             275,
-            FYRatio(275, 365)
+            FYRatio(275, 366)
           ),
-          23.08
+          23.09
         ).valid
     }
 
@@ -1000,31 +1000,31 @@ class MarginalReliefCalculatorImplSpec extends AnyWordSpec with Matchers {
       val result = marginalReliefCalculator.compute(
         LocalDate.of(2023, 1, 1),
         LocalDate.of(2023, 12, 31),
-        50000,
-        10000,
-        Some(1),
+        60000,
+        0,
+        Some(2),
         None,
         None
       )
       result shouldBe
         DualResult(
-          FlatRate(2022, 2342.47, 19.0, 12328.77, 2465.75, 14794.52, 90),
+          FlatRate(2022, 2810.96, 19.0, 14794.52, 0.0, 14794.52, 90),
           MarginalRate(
             2023,
-            9417.81,
+            11301.37,
             25.0,
-            8805.65,
-            23.38,
-            612.16,
-            37671.23,
-            7534.25,
+            11040.24,
+            24.42,
+            261.13,
             45205.48,
-            18835.62,
-            94178.08,
+            0.0,
+            45205.48,
+            12522.77,
+            62613.84,
             275,
-            FYRatio(275, 365)
+            FYRatio(275, 366)
           ),
-          22.3
+          23.09
         ).valid
     }
 


### PR DESCRIPTION
Current calculation logic in MRC only handles cases when both financial years (in an accounting period) are the years that have marginal relief available for. For all other cases, it is defaulting to flat-rate logic which does not use days in FY but days in AP being leap year or not.

So, for 2023 FY (2023/2024) when the marginal relief is available, it should take both into consideration and use FY days for ratio.

Fix is to treat non-relief FY as a year with no URMA there by allowing the calculator to use FY days (rather than AP days) for calculation.